### PR TITLE
Disable CGO to avoid problems with run coredns binary

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,6 +13,7 @@ jobs:
       DOCKER_USER: ${{ secrets.DOCKER_LOGIN }}
       TAG: master
       ORG: networkservicemesh
+      CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation
Fixes error
```
standard_init_linux.go:211: exec user process caused "no such file or directory"
```