### PR TITLE
add fanout/upstream metadata

### DIFF
--- a/fanout.go
+++ b/fanout.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/debug"
 	"github.com/coredns/coredns/plugin/dnstap"
+	"github.com/coredns/coredns/plugin/metadata"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
@@ -102,6 +103,9 @@ func (f *Fanout) ServeDNS(ctx context.Context, w dns.ResponseWriter, m *dns.Msg)
 	if result == nil {
 		return dns.RcodeServerFailure, timeoutContext.Err()
 	}
+	metadata.SetValueFunc(ctx, "fanout/upstream", func() string {
+		return result.client.Endpoint()
+	})
 	if result.err != nil {
 		return dns.RcodeServerFailure, result.err
 	}


### PR DESCRIPTION
I would like to mimic https://github.com/coredns/coredns/commit/32cc745dc215b1474d211a219327ae3701fd6f28 for fanout plugin, we would be using this metadata for our analytics and we would appreciate having this also in fanout