### PR TITLE
qfix: dockerfile path is incorrect for docker push jobs

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,6 +16,13 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+      - name: "Build coredns binary"
+        run: |
+          go build -o coredns/coredns coredns/main.go
+
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: "Build and push"
         uses: docker/build-push-action@v2
         with:
-          file: Dockerfile
+          file: coredns/Dockerfile
           context: .
           push: true
           tags: ${{ steps.metaci.outputs.tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,13 @@ jobs:
         with:
           ref: refs/heads/${{github.event.workflow_run.head_branch}}
 
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+      - name: "Build coredns binary"
+        run: |
+          go build -o coredns/coredns coredns/main.go
+
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: "Build and push"
         uses: docker/build-push-action@v2
         with:
-          file: Dockerfile
+          file: coredns/Dockerfile
           context: .
           push: true
           tags: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.get-tag-step.outputs.tag }}"


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Fixes

```
Error: buildx failed with: error: failed to solve: failed to read dockerfile: open /tmp/buildkit-mount809933122/Dockerfile: no such file or directory
```