### PR TITLE
race policy

### DIFF
--- a/fanout.go
+++ b/fanout.go
@@ -40,6 +40,7 @@ type Fanout struct {
 	excludeDomains Domain
 	tlsServerName  string
 	timeout        time.Duration
+	race           bool
 	net            string
 	from           string
 	attempts       int
@@ -140,6 +141,9 @@ func (f *Fanout) getFanoutResult(ctx context.Context, responseCh <-chan *respons
 			}
 			if r.err != nil {
 				break
+			}
+			if f.race {
+				return r
 			}
 			if r.response.Rcode != dns.RcodeSuccess {
 				break

--- a/setup.go
+++ b/setup.go
@@ -161,6 +161,8 @@ func parseValue(v string, f *Fanout, c *caddyfile.Dispenser) error {
 		return parseWorkerCount(f, c)
 	case "timeout":
 		return parseTimeout(f, c)
+	case "race":
+		return parseRace(f, c)
 	case "except":
 		return parseIgnored(f, c)
 	case "except-file":
@@ -182,6 +184,14 @@ func parseTimeout(f *Fanout, c *caddyfile.Dispenser) error {
 	val := c.Val()
 	f.timeout, err = time.ParseDuration(val)
 	return err
+}
+
+func parseRace(f *Fanout, c *caddyfile.Dispenser) error {
+	if c.NextArg() {
+		return c.ArgErr()
+	}
+	f.race = true
+	return nil
 }
 
 func parseIgnoredFromFile(f *Fanout, c *caddyfile.Dispenser) error {


### PR DESCRIPTION
[#issues 47](https://github.com/networkservicemesh/fanout/issues/47)
New feature that gives priority to the first result

**race policy**
- gives priority to the first result,
- whether it is negative or not,
- as long as it is a standard DNS result.