### PR TITLE
Use network "tcp" when calling tls.DialWithDialer

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ func NewClient(addr, net string) Client {
 // SetTLSConfig sets tls config for client
 func (c *client) SetTLSConfig(cfg *tls.Config) {
 	if cfg != nil {
-		c.net = tcptlc
+		c.net = tcptls
 	}
 	c.transport.SetTLSConfig(cfg)
 }

--- a/const.go
+++ b/const.go
@@ -26,7 +26,7 @@ const (
 	defaultTimeout = 30 * time.Second
 	readTimeout    = 2 * time.Second
 	attemptDelay   = time.Millisecond * 100
-	tcptlc         = "tcp-tls"
+	tcptls         = "tcp-tls"
 	tcp            = "tcp"
 	udp            = "udp"
 )

--- a/setup.go
+++ b/setup.go
@@ -263,7 +263,7 @@ func parseProtocol(f *Fanout, c *caddyfile.Dispenser) error {
 		return c.ArgErr()
 	}
 	net := strings.ToLower(c.Val())
-	if net != tcp && net != udp && net != tcptlc {
+	if net != tcp && net != udp && net != tcptls {
 		return errors.New("unknown network protocol")
 	}
 	f.net = net

--- a/transport.go
+++ b/transport.go
@@ -79,7 +79,7 @@ func (t *transportImpl) dial(ctx context.Context, c *dns.Client) (*dns.Conn, err
 	var conn = new(dns.Conn)
 	var err error
 	if network == tcptlc {
-		conn.Conn, err = tls.DialWithDialer(&d, network, t.addr, c.TLSConfig)
+		conn.Conn, err = tls.DialWithDialer(&d, "tcp", t.addr, c.TLSConfig)
 	} else {
 		conn.Conn, err = d.DialContext(ctx, network, t.addr)
 	}

--- a/transport.go
+++ b/transport.go
@@ -51,9 +51,9 @@ func (t *transportImpl) SetTLSConfig(c *tls.Config) {
 // Dial dials the address configured in transportImpl, potentially reusing a connection or creating a new one.
 func (t *transportImpl) Dial(ctx context.Context, network string) (*dns.Conn, error) {
 	if t.tlsConfig != nil {
-		network = tcptlc
+		network = tcptls
 	}
-	if network == tcptlc {
+	if network == tcptls {
 		return t.dial(ctx, &dns.Client{Net: network, Dialer: &net.Dialer{Timeout: maxTimeout}, TLSConfig: t.tlsConfig})
 	}
 	return t.dial(ctx, &dns.Client{Net: network, Dialer: &net.Dialer{Timeout: maxTimeout}})
@@ -78,7 +78,7 @@ func (t *transportImpl) dial(ctx context.Context, c *dns.Client) (*dns.Conn, err
 	}
 	var conn = new(dns.Conn)
 	var err error
-	if network == tcptlc {
+	if network == tcptls {
 		conn.Conn, err = tls.DialWithDialer(&d, "tcp", t.addr, c.TLSConfig)
 	} else {
 		conn.Conn, err = d.DialContext(ctx, network, t.addr)


### PR DESCRIPTION
Fixes #41 

Set network to "tcp" instead "tcp-tls". This correctly connects to DoT servers.

Also renamed constant `tcptlc` to `tcptls` under the assumption that this is a typo. If there's a reason for this name let me know.