### PR TITLE
init rand once

### DIFF
--- a/fanout_test.go
+++ b/fanout_test.go
@@ -21,6 +21,7 @@ package fanout
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"strings"
@@ -29,15 +30,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
-
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
-	"github.com/stretchr/testify/suite"
-
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 )
 
 const testQuery = "example1."
@@ -390,7 +389,7 @@ func (t *fanoutTestSuite) TestServerCount() {
 	c1 := NewClient(s1.addr, t.network)
 	c2 := NewClient(s2.addr, t.network)
 	f := New()
-	f.serverSelectionPolicy = &weightedPolicy{loadFactor: []int{50, 100}}
+	f.serverSelectionPolicy = &weightedPolicy{loadFactor: []int{50, 100}, r: rand.New(rand.NewSource(1))}
 	f.net = t.network
 	f.from = "."
 	f.addClient(c1)

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -389,7 +389,11 @@ func (t *fanoutTestSuite) TestServerCount() {
 	c1 := NewClient(s1.addr, t.network)
 	c2 := NewClient(s2.addr, t.network)
 	f := New()
-	f.serverSelectionPolicy = &weightedPolicy{loadFactor: []int{50, 100}, r: rand.New(rand.NewSource(1))}
+	f.serverSelectionPolicy = &weightedPolicy{
+		loadFactor: []int{50, 100},
+		//nolint:gosec // init rand with constant seed to get predefined result
+		r: rand.New(rand.NewSource(1)),
+	}
 	f.net = t.network
 	f.from = "."
 	f.addClient(c1)

--- a/internal/selector/rand.go
+++ b/internal/selector/rand.go
@@ -19,7 +19,6 @@ package selector
 
 import (
 	"math/rand"
-	"time"
 )
 
 // WeightedRand selector picks elements randomly based on their weights
@@ -31,13 +30,12 @@ type WeightedRand[T any] struct {
 }
 
 // NewWeightedRandSelector inits WeightedRand by copying source values and calculating total weight
-func NewWeightedRandSelector[T any](values []T, weights []int) *WeightedRand[T] {
+func NewWeightedRandSelector[T any](values []T, weights []int, r *rand.Rand) *WeightedRand[T] {
 	wrs := &WeightedRand[T]{
 		values:      make([]T, len(values)),
 		weights:     make([]int, len(weights)),
 		totalWeight: 0,
-		//nolint:gosec // it's overhead to use crypto/rand here
-		r: rand.New(rand.NewSource(time.Now().UnixNano())),
+		r:           r,
 	}
 	// copy the underlying array values as we're going to modify content of slices
 	copy(wrs.values, values)

--- a/internal/selector/rand_test.go
+++ b/internal/selector/rand_test.go
@@ -64,7 +64,7 @@ func TestWeightedRand_Pick(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			// init rand with constant seed to get predefined result
+			//nolint:gosec // init rand with constant seed to get predefined result
 			r := rand.New(rand.NewSource(1))
 
 			wrs := NewWeightedRandSelector(tc.values, tc.weights, r)

--- a/internal/selector/rand_test.go
+++ b/internal/selector/rand_test.go
@@ -64,10 +64,10 @@ func TestWeightedRand_Pick(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			wrs := NewWeightedRandSelector(tc.values, tc.weights)
 			// init rand with constant seed to get predefined result
-			//nolint:gosec
-			wrs.r = rand.New(rand.NewSource(1))
+			r := rand.New(rand.NewSource(1))
+
+			wrs := NewWeightedRandSelector(tc.values, tc.weights, r)
 
 			actual := make([]string, 0, tc.picksCount)
 			for i := 0; i < tc.picksCount; i++ {

--- a/policy.go
+++ b/policy.go
@@ -16,7 +16,11 @@
 
 package fanout
 
-import "github.com/networkservicemesh/fanout/internal/selector"
+import (
+	"math/rand"
+
+	"github.com/networkservicemesh/fanout/internal/selector"
+)
 
 type policy interface {
 	selector(clients []Client) clientSelector
@@ -38,9 +42,10 @@ func (p *sequentialPolicy) selector(clients []Client) clientSelector {
 // weightedPolicy is used to select clients randomly based on its loadFactor (weights)
 type weightedPolicy struct {
 	loadFactor []int
+	r          *rand.Rand
 }
 
 // creates new weighted random selector of provided clients based on loadFactor
 func (p *weightedPolicy) selector(clients []Client) clientSelector {
-	return selector.NewWeightedRandSelector(clients, p.loadFactor)
+	return selector.NewWeightedRandSelector(clients, p.loadFactor, p.r)
 }

--- a/setup.go
+++ b/setup.go
@@ -19,6 +19,7 @@
 package fanout
 
 import (
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -173,7 +174,10 @@ func initServerSelectionPolicy(f *Fanout) error {
 
 	f.serverSelectionPolicy = &sequentialPolicy{}
 	if f.policyType == policyWeightedRandom {
-		f.serverSelectionPolicy = &weightedPolicy{loadFactor: loadFactor}
+		f.serverSelectionPolicy = &weightedPolicy{
+			loadFactor: loadFactor,
+			r:          rand.New(rand.NewSource(time.Now().UnixNano())),
+		}
 	}
 
 	return nil

--- a/setup.go
+++ b/setup.go
@@ -176,7 +176,8 @@ func initServerSelectionPolicy(f *Fanout) error {
 	if f.policyType == policyWeightedRandom {
 		f.serverSelectionPolicy = &weightedPolicy{
 			loadFactor: loadFactor,
-			r:          rand.New(rand.NewSource(time.Now().UnixNano())),
+			//nolint:gosec // it's overhead to use crypto/rand here
+			r: rand.New(rand.NewSource(time.Now().UnixNano())),
 		}
 	}
 


### PR DESCRIPTION
I did performance testing with fanout plugin and was found that rand.NewSource uses 4.3% of CPU
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bd60ba28-961e-4270-80ef-e76f86a6187f">

Here is a fix that moves rand initialization to weightedPolicy, so that rand is initialized only once.

Profile after the fix

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/3907e780-18ce-4516-a12b-584b3188e7cc">
